### PR TITLE
fix storage error on Windows

### DIFF
--- a/kodiswift/storage.py
+++ b/kodiswift/storage.py
@@ -14,6 +14,7 @@ import collections
 import json
 import os
 import time
+import shutil
 from datetime import datetime
 
 try:
@@ -119,7 +120,7 @@ class PersistentStorage(collections.MutableMapping):
             if os.path.exists(temp_file):
                 os.remove(temp_file)
             raise
-        os.rename(temp_file, self.file_path)
+        shutil.move(temp_file, self.file_path)
 
 
 class TimedStorage(PersistentStorage):


### PR DESCRIPTION
os.rename error on windows
#4

`NOTE: IGNORING THIS CAN LEAD TO MEMORY LEAKS! Error Type: Error Contents: (183, '') Traceback (most recent call last): File "D:\Program Files (x86)\Kodi17\portable_data\addons\plugin.video.bigmovies\default.py", line 6, in plugin.run() File "D:\Program Files (x86)\Kodi17\portable_data\addons\plugin.video.bigmovies\kodiswift\plugin.py", line 314, in run storage.close() File "D:\Program Files (x86)\Kodi17\portable_data\addons\plugin.video.bigmovies\kodiswift\storage.py", line 105, in close self.sync() File "D:\Program Files (x86)\Kodi17\portable_data\addons\plugin.video.bigmovies\kodiswift\storage.py", line 163, in sync super(TimedStorage, self).sync() File "D:\Program Files (x86)\Kodi17\portable_data\addons\plugin.video.bigmovies\kodiswift\storage.py", line 123, in sync os.rename(temp_file, self.file_path) WindowsError: (183, '')`
