### PR TITLE
Made it possible to actually access args in a redirected request

### DIFF
--- a/kodiswift/listitem.py
+++ b/kodiswift/listitem.py
@@ -304,6 +304,7 @@ class ListItem(object):
 
         if is_playable:
             listitem.playable = True
+            listitem.is_folder = False
 
         if properties:
             # Need to support existing tuples, but prefer to have a dict for

--- a/kodiswift/plugin.py
+++ b/kodiswift/plugin.py
@@ -295,9 +295,9 @@ class Plugin(XBMCMixin):
     def redirect(self, url):
         """Used when you need to redirect to another view, and you only
         have the final plugin:// url."""
-        # TODO: Should we be overriding self.request with the new request?
         new_request = self._parse_request(url=url, handle=self.request.handle)
         log.debug('Redirecting %s to %s', self.request.path, new_request.path)
+        self._request = new_request
         return self._dispatch(new_request.path)
 
     def run(self):

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -291,6 +291,23 @@ class TestBasicRouting(TestCase):
             resp = test_run('/')
             self.assertEqual('Hello Videos', resp[0].get_label())
 
+    def test_redirect_with_arguments(self):
+        plugin = new_plugin()
+
+        @plugin.route('/')
+        def main_menu():
+            url = plugin.url_for('videos', label='Entertaining video')
+            return plugin.redirect(url)
+
+        @plugin.route('/videos/')
+        def videos():
+            return [{'label': plugin.request.args.get('label')[0]}]
+
+        with preserve_cli_mode(cli_mode=False):
+            test_run = _test_plugin_runner(plugin)
+            resp = test_run('/')
+            self.assertEqual('Entertaining video', resp[0].get_label())
+
 
 class TestUnsyncedCaches(TestCase):
     def test_unsyced_caches(self):


### PR DESCRIPTION
This pull request might break backward compatibility. 

I think it's a good idea to mirror how redirects work with HTTP, especially since it's impossible to access args with a redirected request.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sinap/kodiswift/22)

<!-- Reviewable:end -->
