### PR TITLE
Documentation updates

### DIFF
--- a/docs/caching.rst
+++ b/docs/caching.rst
@@ -9,7 +9,7 @@ user experience of your addon. swift offers a simple storage mechanism that
 allows you to store arbitraty python objects to use between requests.
 
 .. warning::
-    
+
     The current implementation of kodiswift's storage is very basic and is not
     thread safe. If your addon does background calls via the context menu and
     manipulates storages in these backgound threads, you might run into some
@@ -30,7 +30,7 @@ get a cache, simply call the ``get_storage`` method.
     people.update({'dave': 'accountant'})
 
     people.items()
-    # [('jon', 'deveoper'), ('dave', 'accountant')]
+    # [('jon', 'developer'), ('dave', 'accountant')]
 
 Caches are automatically persisted to disk each time an addon finishes
 execution. If you would like to sync the cache to disk manually, you can call

--- a/docs/commandline.rst
+++ b/docs/commandline.rst
@@ -29,7 +29,7 @@ run
 ~~~
 
 When running an addon on the command line, there are three different run modes
-available, once_, interactive_, and crawl_. 
+available, once_, interactive_, and crawl_.
 
 There is also a second positional argument, ``url``, which is optional. By
 default, kodiswift will run the root URL of your addon (a path of '/'), e.g.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -17,7 +17,7 @@ The easiest way to get the most recent version of kodiswift for Kodi is to
 install an addon that requires kodiswift. You can find a list of such addons
 on the :ref:`poweredby` page. The other options is download the current Kodi
 distribution from https://github.com/jbeluch/kodiswift-xbmc-dist/tags and
-unpack it into your addons folder.  
+unpack it into your addons folder.
 
 Now, on to installing kodiswift for use on the command line.
 

--- a/docs/item.rst
+++ b/docs/item.rst
@@ -75,7 +75,7 @@ info
 
 A dictionary of key/values of metadata information about the item. See the
 `Kodi docs
-<http://mirrors.xbmc.org/docs/python-docs/xbmcgui.html#ListItem-setInfo>`_ for
+<http://mirrors.kodi.tv/docs/python-docs/16.x-jarvis/xbmcgui.html#ListItem-setInfo>`_ for
 a list of valid info items. Keys are always strings but values should be the
 correct type required by Kodi.
 
@@ -86,7 +86,7 @@ properties
 ----------
 
 A dict of properties, similar to info-labels. See
-http://mirrors.xbmc.org/docs/python-docs/xbmcgui.html#ListItem-setProperty for
+`ListItem documentation <http://mirrors.kodi.tv/docs/python-docs/16.x-jarvis/xbmcgui.html#ListItem-setProperty>`_ for
 more information.
 
 
@@ -96,7 +96,7 @@ context_menu
 A list of tuples, where each tuple is of length 2. The tuple should be (label,
 action) where action is a string representing a built-in Kodi function. See the
 `Kodi documentation
-<http://mirrors.xbmc.org/docs/python-docs/xbmcgui.html#ListItem-addContextMenuItems>`_
+<http://mirrors.kodi.tv/docs/python-docs/16.x-jarvis/xbmcgui.html#ListItem-addContextMenuItems>`_
 for more details and `Using the Context Menu` for some example code.
 
 
@@ -122,7 +122,7 @@ info_type
 
 Used in conjunction with `info`. The default value is usually configured
 automatically from your addon.xml. See
-http://mirrors.xbmc.org/docs/python-docs/xbmcgui.html#ListItem-setInfo for
+`setInfo documentation <http://mirrors.kodi.tv/docs/python-docs/16.x-jarvis/xbmcgui.html#ListItem-setInfo>`_ for
 valid values.
 
 
@@ -131,5 +131,5 @@ stream_info
 
 A dict where each key is a stream type and each value is another dict of stream
 values. See
-http://mirrors.xbmc.org/docs/python-docs/xbmcgui.html#ListItem-addStreamInfo
+`addStreamInfo documentation <http://mirrors.kodi.tv/docs/python-docs/16.x-jarvis/xbmcgui.html#ListItem-addStreamInfo>`_
 for more information.

--- a/docs/patterns.rst
+++ b/docs/patterns.rst
@@ -101,7 +101,7 @@ Some example code:
 
         return plugin.finish(items, update_listing=True)
 
-The first thing to notice about our view, is that it takes a page number as a 
+The first thing to notice about our view, is that it takes a page number as a
 URL parameter. We then pass the page number to the API call, get_videos(), to
 return the correct data based on the current page. Then we create our own
 previous/next list items depending on the current page. Lastly, we are
@@ -141,7 +141,7 @@ Adding sort methods
 
 Sort methods enable the user to sort a directory listing in different ways. You
 can see the available sort methods `here
-<http://mirrors.xbmc.org/docs/python-docs/xbmcplugin.html#-addSortMethod>`_, or
+<http://mirrors.kodi.tv/docs/python-docs/16.x-jarvis/xbmcplugin.html#-addSortMethod>`_, or
 by doing ``dir(kodiswift.SortMethod)``. The simplest way to add sort methods to
 your views is to call plugin.finish() with a sort_methods argument and return
 the result from your view (this is what kodiswift does behind the scenes
@@ -197,10 +197,10 @@ the *context_menu* key in an item dict. The value should be a list of 2-tuples.
 Each tuple corresponds to a context menu item, and should be of the format
 (display_string, action) where action is a string corresponding to one of
 Kodi's `built-in functions`_. See `Kodi's documentation
-<http://mirrors.xbmc.org/docs/python-docs/xbmcgui.html#ListItem-addContextMenuItems>`_
+<http://mirrors.kodi.tv/docs/python-docs/16.x-jarvis/xbmcgui.html#ListItem-addContextMenuItems>`_
 for more information.
 
-.. _`built-in functions`: http://wiki.xbmc.org/?title=List_of_Built_In_Functions
+.. _`built-in functions`: http://kodi.wiki/view/List_of_Built_In_Functions
 
 The most common actions are `Kodi.RunPlugin()` and `Kodi.Container.Update()`.
 RunPlugin takes a single argument, a URL for a plugin (you can create a URL
@@ -220,7 +220,7 @@ Here is a quick example of updating the context menu.
     from kodiswift import actions
 
     @plugin.url('/favorites/add/<url>')
-    def add_to_favs(url):
+    def add_to_favorites(url):
         # this is a background view
         ...
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -32,7 +32,7 @@ Before going any further, you should already be familiar with the general file
 structure and necessary files for an Kodi addon. If not, please spend a few
 minutes reading about addons in the Kodi wiki_.
 
-.. _wiki: http://wiki.xbmc.org/index.php?title=Add-on_development
+.. _wiki: http://kodi.wiki/view/Add-on_development
 
 
 Creating the Plugin Skeleton
@@ -54,7 +54,7 @@ Below is an example session::
     I'm going to ask you a few questions to get this project started.
     What is your plugin name? : Hello Kodi
     Enter your plugin id. [plugin.video.helloxbmc]:
-    Enter parent folder (where to create project) [/private/tmp]: 
+    Enter parent folder (where to create project) [/private/tmp]:
     Enter provider name : Jonathan Beluch (jbel)
     Projects successfully created in /private/tmp/plugin.video.helloxbmc.
     Done.
@@ -300,7 +300,7 @@ versions of these modules.
 
 Going further
 -------------
- 
+
 This should be enough to get started with your first simple Kodi addon. If
 you'd like more information, please check out the detailed :ref:`tutorial` and
 also review common :ref:`patterns`.

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -27,8 +27,8 @@ files and folders for you. So we'll do just that::
 
         I'm going to ask you a few questions to get this project started.
         What is your plugin name? : Academic Earth Tutorial
-        Enter your plugin id. [plugin.video.academicearthtutorial]: 
-        Enter parent folder (where to create project) [/tmp]: 
+        Enter your plugin id. [plugin.video.academicearthtutorial]:
+        Enter parent folder (where to create project) [/tmp]:
         Enter provider name : Jonathan Beluch (jbel)
         Projects successfully created in /tmp/plugin.video.academicearthtutorial.
         Done.
@@ -60,7 +60,7 @@ If you open the addon.xml file, you'll notice that kodiswift is already in your 
 .. sourcecode:: xml
 
     <import addon="xbmc.python" version="2.0" />
-    <import addon="script.module.kodiswift" version="1.1.1" />
+    <import addon="script.module.kodiswift" version="0.0.7" />
 
 We'll add BeautifulSoup right after those lines:
 


### PR DESCRIPTION
 - context menu example fixed
 - updated all urls to point to kodi.tv instead of xbmc.org
 - all direct link to api docs link to jarvis specific urls.
 - typos and trailing whitespaces here and there

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sinap/kodiswift/24)
<!-- Reviewable:end -->
