### PR TITLE
fixed kodiswift console output

### DIFF
--- a/kodiswift/cli/console.py
+++ b/kodiswift/cli/console.py
@@ -37,7 +37,7 @@ def display_listitems(items, url):
             output.append('[%s] %s (%s)' % (
                 str(i).rjust(num_width),
                 item.label.ljust(label_width),
-                item.label))
+                item.path))
 
         line_width = get_max_len(output)
         output.append('-' * line_width)


### PR DESCRIPTION
Running addon via console from kodiswift showed listitem label on both label
and path columns. Now, label and path are shown properly as described in the
example outputs of the documentation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sinap/kodiswift/25)
<!-- Reviewable:end -->
