### PR TITLE
Increasing test coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,6 @@
+[run]
+omit =
+  fabfile.py
+  setup.py
+  tests/**/*.py
+  tests/*.py

--- a/tests/cli/test_console.py
+++ b/tests/cli/test_console.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 import unittest
-
+from mock import patch
+import StringIO
 from kodiswift.cli import console
+from kodiswift.listitem import ListItem
 
 
 class TestConsole(unittest.TestCase):
@@ -9,3 +11,45 @@ class TestConsole(unittest.TestCase):
         items = ['a', 'bb', 'ccc', 'dddd']
         self.assertEqual(console.get_max_len(items), 4)
         self.assertEqual(console.get_max_len([]), 0)
+
+    def test_display_video(self):
+        items = [{'label': 'X', 'path': 'Y'}, {'label': 'Z', 'path': 'Q'} ]
+        list_items = [ListItem.from_dict(**item) for item in items]
+        with patch('sys.stdout', new=StringIO.StringIO()) as stdout:
+            console.display_video( list_items )
+
+        output = stdout.getvalue().strip()
+        self.assertEquals(output,'-------------------\nPlaying Media Z (Q)\n-------------------\n[0] X (Y)')
+
+    def test_display_video_form_listitems(self):
+        items = [{'label': '..', 'path': 'Y'}, {'label': 'Z', 'path': 'Q', 'played': True} ]
+        list_items = [ListItem.from_dict(**item) for item in items]
+        list_items[1].set_played(True)
+        with patch('sys.stdout', new=StringIO.StringIO()) as stdout:
+            console.display_listitems( list_items, "PARENT_URL" )
+
+        output = stdout.getvalue().strip()
+        self.assertEquals(output,'-------------------\nPlaying Media Z (Q)\n-------------------\n[0] .. (Y)')
+
+    def test_display_listitems_with_single_item(self):
+        items = [{'label': '..', 'path': 'Y'}, {'label': 'Z', 'path': 'Q'} ]
+        list_items = [ListItem.from_dict(**item) for item in items]
+        with patch('sys.stdout', new=StringIO.StringIO()) as stdout:
+            console.display_listitems( list_items,'PARENT_URL' )
+
+        output = stdout.getvalue().strip()
+        self.assertEquals(output, '===========\nCurrent URL: PARENT_URL\n-----------\n #  Label Path\n-----------\n[0] .. (..)\n[1] Z  (Z)\n-----------')
+
+    def test_display_listitems_with_multiple_items(self):
+        items = [
+            {'label': 'A_LABEL', 'path': 'B_PATH'},
+            {'label': 'B_LABEL', 'path': 'B_PATH'},
+            {'label': 'C_LABEL', 'path': 'C_PATH'}
+            ]
+        list_items = [ListItem.from_dict(**item) for item in items]
+
+        with patch('sys.stdout', new=StringIO.StringIO()) as stdout:
+            console.display_listitems( list_items,'PARENT_URL' )
+
+        output = stdout.getvalue().strip()
+        self.assertEquals(output,'=====================\nCurrent URL: PARENT_URL\n---------------------\n #  Label   Path\n---------------------\n[0] A_LABEL (A_LABEL)\n[1] B_LABEL (B_LABEL)\n[2] C_LABEL (C_LABEL)\n---------------------')

--- a/tests/test_listitem.py
+++ b/tests/test_listitem.py
@@ -70,6 +70,37 @@ class TestListItem(unittest.TestCase):
         self.assertEqual(item.path, 'baz')
         self.assertEqual(item.get_path(), 'baz')
 
+    def test_poster(self):
+        item = ListItem()
+        self.assertIsNone(item.poster)
+
+        item.poster = 'bar'
+        self.assertEqual(item.poster, 'bar')
+        item.poster = 'baz'
+        self.assertEqual(item.poster, 'baz')
+
+    def test_played(self):
+        item = ListItem()
+        self.assertEqual(item.played, False)
+
+        item.played = True
+        self.assertEqual(item.played, True)
+        item.played = False
+        self.assertEqual(item.played, False)
+
+    def test_art(self):
+        item = ListItem()
+        art = {'thumb': None, 'icon': None}
+        self.assertEqual(item.art, art)
+
+        art2 = {'thumb': 'something', 'icon': 'else'}
+        item.art = art2
+        self.assertEqual(item.art, art2)
+
+        item.set_art(art)
+        self.assertEqual(item.art, art)
+
+
     def test_context_menu(self):
         menu_items = [('label1', 'foo'), ('label2', 'bar')]
         item = ListItem()
@@ -80,6 +111,10 @@ class TestListItem(unittest.TestCase):
         menu_items.append(extra_menu_item)
         item.add_context_menu_items([extra_menu_item])
         self.assertEqual(item.get_context_menu_items(), menu_items)
+
+        # Verify replace_items branch gets executed and works.
+        item.add_context_menu_items([extra_menu_item], True)
+        self.assertEqual(item.get_context_menu_items(), [extra_menu_item])
 
     def test_set_info(self):
         # noinspection PyUnresolvedReferences
@@ -163,6 +198,13 @@ class TestListItem(unittest.TestCase):
         item = ListItem()
         self.assertEqual(item.as_tuple(), (None, item._listitem, True))
 
+
+    def test___str__(self):
+        item = ListItem()
+        item.path = "somePath"
+        item.label = "sameLabel"
+        self.assertEqual(item.__str__(), u"sameLabel (somePath)")
+        self.assertEqual(str(item), u"sameLabel (somePath)")
 
 class TestListItemAsserts(unittest.TestCase):
     def test_non_basestring_key(self):


### PR DESCRIPTION
 - Use coveragerc to exclude irrelevant python files
 - tests for display_listitems & display_video