### PR TITLE
Support for python 2 and 3

### DIFF
--- a/kodiswift/__init__.py
+++ b/kodiswift/__init__.py
@@ -67,7 +67,7 @@ except ImportError:
     xbmcaddon = _Module(xbmcaddon)
     xbmcvfs = _Module(xbmcvfs)
     for m in (xbmc, xbmcgui, xbmcplugin, xbmcaddon, xbmcvfs):
-        name = reversed(m.__name__.rsplit('.', 1)).next()
+        name = next(reversed(m.__name__.rsplit('.', 1)))
         sys.modules[name] = m
 
 from kodiswift.storage import TimedStorage

--- a/kodiswift/cli/console.py
+++ b/kodiswift/cli/console.py
@@ -8,9 +8,11 @@
     :copyright: (c) 2012 by Jonathan Beluch
     :license: GPLv3, see LICENSE for more details.
 """
-from __future__ import print_function, absolute_import
+from __future__ import print_function
 
 
+from builtins import input
+from builtins import str
 def get_max_len(items):
     """Returns the max of the lengths for the provided items"""
     try:
@@ -51,7 +53,7 @@ def display_listitems(items, url):
                             'Label'.ljust(label_width)),
             '-' * line_width,
         ]
-        print('\n'.join(header + output))
+        print(u'\n'.join(header + output))
 
 
 def display_video(items):
@@ -72,14 +74,14 @@ def display_video(items):
         '-' * line_width,
         parent_line,
     ]
-    print('\n'.join(output))
+    print(u'\n'.join(output))
 
 
 def get_user_choice(items):
     """Returns the selected item from provided items or None if 'q' was
     entered for quit.
     """
-    choice = raw_input('Choose an item or "q" to quit: ')
+    choice = eval(input('Choose an item or "q" to quit: '))
     while choice != 'q':
         try:
             item = items[int(choice)]
@@ -87,12 +89,12 @@ def get_user_choice(items):
             return item
         except ValueError:
             # Passed something that couldn't be converted with int()
-            choice = raw_input('You entered a non-integer. Choice must be an'
-                               ' integer or "q": ')
+            choice = eval(input('You entered a non-integer. Choice must be an'
+                               ' integer or "q": '))
         except IndexError:
             # Passed an integer that was out of range of the list of urls
-            choice = raw_input('You entered an invalid integer. Choice must '
-                               'be from above url list or "q": ')
+            choice = eval(input('You entered an invalid integer. Choice must '
+                               'be from above url list or "q": '))
     return None
 
 
@@ -100,4 +102,4 @@ def continue_or_quit():
     """Prints an exit message and returns False if the user wants to
     quit.
     """
-    return raw_input('Enter to continue or "q" to quit') != 'q'
+    return eval(input('Enter to continue or "q" to quit')) != 'q'

--- a/kodiswift/common.py
+++ b/kodiswift/common.py
@@ -10,10 +10,14 @@ This module contains some common helpful functions.
 """
 from __future__ import absolute_import
 
-import urllib
+from future import standard_library
+standard_library.install_aliases()
+from past.builtins import basestring
+from builtins import object
+import urllib.request, urllib.parse, urllib.error
 
 try:
-    import cPickle as pickle
+    import pickle as pickle
 except ImportError:
     import pickle
 
@@ -39,7 +43,7 @@ def kodi_url(url, **options):
     Returns:
         str:
     """
-    options = urllib.urlencode(options)
+    options = urllib.parse.urlencode(options)
     if options:
         return url + '|' + options
     return url
@@ -54,7 +58,7 @@ def clean_dict(data):
     Returns:
         dict:
     """
-    return dict((k, v) for k, v in data.items() if v is not None)
+    return dict((k, v) for k, v in list(data.items()) if v is not None)
 
 
 def pickle_dict(items):
@@ -70,7 +74,7 @@ def pickle_dict(items):
     """
     ret = {}
     pickled_keys = []
-    for k, v in items.items():
+    for k, v in list(items.items()):
         if isinstance(v, basestring):
             ret[k] = v
         else:
@@ -102,9 +106,9 @@ def unpickle_args(items):
 
     pickled_keys = pickled[0].split(',')
     ret = {}
-    for k, v in items.items():
+    for k, v in list(items.items()):
         if k in pickled_keys:
-            ret[k] = [pickle.loads(val) for val in v]
+            ret[k] = [pickle.loads(val.encode()) for val in v]
         else:
             ret[k] = v
     return ret
@@ -121,7 +125,7 @@ def unpickle_dict(items):
     """
     pickled_keys = items.pop('_pickled', '').split(',')
     ret = {}
-    for k, v in items.items():
+    for k, v in list(items.items()):
         if k in pickled_keys:
             ret[k] = pickle.loads(v)
         else:
@@ -141,7 +145,7 @@ def download_page(url, data=None):
     Returns:
         str: The results of requesting the URL.
     """
-    conn = urllib.urlopen(url, data)
+    conn = urllib.request.urlopen(url, data)
     resp = conn.read()
     conn.close()
     return resp

--- a/kodiswift/constants.py
+++ b/kodiswift/constants.py
@@ -11,6 +11,7 @@ with Kodi.
 """
 from __future__ import absolute_import
 
+from builtins import object
 from kodiswift import xbmcplugin
 
 __all__ = ['SortMethod']

--- a/kodiswift/listitem.py
+++ b/kodiswift/listitem.py
@@ -11,6 +11,8 @@ for xbmcgui.ListItem.
 """
 from __future__ import absolute_import
 
+from past.builtins import basestring
+from builtins import object
 import warnings
 
 from kodiswift import xbmcgui
@@ -310,12 +312,12 @@ class ListItem(object):
             # Need to support existing tuples, but prefer to have a dict for
             # properties.
             if hasattr(properties, 'items'):
-                properties = properties.items()
+                properties = list(properties.items())
             for key, val in properties:
                 listitem.set_property(key, val)
 
         if stream_info:
-            for stream_type, stream_values in stream_info.items():
+            for stream_type, stream_values in list(stream_info.items()):
                 listitem.add_stream_info(stream_type, stream_values)
 
         if context_menu:
@@ -333,7 +335,7 @@ class ListItem(object):
         return self_props == other_props
 
     def __str__(self):
-        return ('%s (%s)' % (self.label, self.path)).encode('utf-8')
+        return '%s (%s)' % (self.label, self.path)
 
     def __repr__(self):
-        return ("<ListItem '%s'>" % self.label).encode('utf-8')
+        return "<ListItem '%s'>" % self.label

--- a/kodiswift/plugin.py
+++ b/kodiswift/plugin.py
@@ -252,7 +252,7 @@ class Plugin(XBMCMixin):
         The route decorator provides the same functionality.
         """
         rule = UrlRule(url_rule, view_func, name, options)
-        if name in self._view_functions.keys():
+        if name in list(self._view_functions.keys()):
             # TODO: Raise exception for ambiguous views during registration
             log.warning('Cannot add url rule "%s" with name "%s". There is '
                         'already a view with that name', url_rule, name)
@@ -276,8 +276,8 @@ class Plugin(XBMCMixin):
             rule = self._view_functions[endpoint]
         except KeyError:
             try:
-                rule = (rule for rule in self._view_functions.values()
-                        if rule.view_func == endpoint).next()
+                rule = next((rule for rule in list(self._view_functions.values())
+                        if rule.view_func == endpoint))
             except StopIteration:
                 raise NotFoundException(
                     '%s does not match any known patterns.' % endpoint)
@@ -308,7 +308,7 @@ class Plugin(XBMCMixin):
 
         # Close any open storages which will persist them to disk
         if hasattr(self, '_unsynced_storage'):
-            for storage in self._unsynced_storage.values():
+            for storage in list(self._unsynced_storage.values()):
                 log.debug('Saving a %s storage to disk at "%s"',
                           storage.file_format, storage.file_path)
                 storage.close()

--- a/kodiswift/request.py
+++ b/kodiswift/request.py
@@ -11,7 +11,10 @@ request from Kodi.
 """
 from __future__ import absolute_import
 
-import urlparse
+from future import standard_library
+standard_library.install_aliases()
+from builtins import object
+import urllib.parse
 
 from kodiswift.common import unpickle_args
 
@@ -40,7 +43,7 @@ class Request(object):
         # urlparse doesn't like the 'plugin' scheme, so pass a protocol
         # relative url, e.g. //plugin.video.helloxbmc/path
         self.scheme, remainder = url.split(':', 1)
-        parts = urlparse.urlparse(remainder)
+        parts = urllib.parse.urlparse(remainder)
         self.netloc, self.path, self.query_string = (
             parts[1], parts[2], parts[4])
-        self.args = unpickle_args(urlparse.parse_qs(self.query_string))
+        self.args = unpickle_args(urllib.parse.parse_qs(self.query_string))

--- a/kodiswift/urls.py
+++ b/kodiswift/urls.py
@@ -10,8 +10,13 @@ This module contains URLRule class for dealing with url patterns.
 """
 from __future__ import absolute_import
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import str
+from past.builtins import basestring
+from builtins import object
 import re
-from urllib import urlencode, unquote_plus, quote_plus
+from urllib.parse import urlencode, unquote_plus, quote_plus
 
 from kodiswift.common import pickle_dict, unpickle_dict
 
@@ -105,14 +110,14 @@ class UrlRule(object):
 
         # urlunencode the values
         items = dict((key, unquote_plus(val))
-                     for key, val in m.groupdict().items())
+                     for key, val in list(m.groupdict().items()))
 
         # unpickle any items if present
         items = unpickle_dict(items)
 
         # We need to update our dictionary with default values provided in
         # options if the keys don't already exist.
-        [items.setdefault(key, val) for key, val in self._options.items()]
+        [items.setdefault(key, val) for key, val in list(self._options.items())]
         return self._view_func, items
 
     def _make_path(self, items):
@@ -121,7 +126,7 @@ class UrlRule(object):
         Uses this url rule's url pattern and replaces instances of <var_name>
         with the appropriate value from the items dict.
         """
-        for key, val in items.items():
+        for key, val in list(items.items()):
             if not isinstance(val, basestring):
                 raise TypeError('Value "%s" for key "%s" must be an instance'
                                 ' of basestring' % (val, key))
@@ -132,7 +137,7 @@ class UrlRule(object):
         except AttributeError:
             # Old version of python
             path = self._url_format
-            for key, val in items.items():
+            for key, val in list(items.items()):
                 path = path.replace('{%s}' % key, val)
         return path
 
@@ -162,23 +167,23 @@ class UrlRule(object):
                      need to persist a large amount of data between requests.
         """
         # Convert any ints and longs to strings
-        for key, val in items.items():
-            if isinstance(val, (int, long)):
+        for key, val in list(items.items()):
+            if isinstance(val, int):
                 items[key] = str(val)
 
         # First use our defaults passed when registering the rule
-        url_items = dict((key, val) for key, val in self._options.items()
+        url_items = dict((key, val) for key, val in list(self._options.items())
                          if key in self._keywords)
 
         # Now update with any items explicitly passed to url_for
-        url_items.update((key, val) for key, val in items.items()
+        url_items.update((key, val) for key, val in list(items.items())
                          if key in self._keywords)
 
         # Create the path
         path = self._make_path(url_items)
 
         # Extra arguments get tacked on to the query string
-        qs_items = dict((key, val) for key, val in items.items()
+        qs_items = dict((key, val) for key, val in list(items.items())
                         if key not in self._keywords)
         qs = self._make_qs(qs_items)
 

--- a/kodiswift/xbmcmixin.py
+++ b/kodiswift/xbmcmixin.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 
+from past.builtins import basestring, unicode
+from builtins import object
 import os
 import warnings
 from datetime import timedelta

--- a/tests/cli/test_console.py
+++ b/tests/cli/test_console.py
@@ -1,7 +1,9 @@
+from future import standard_library
+standard_library.install_aliases()
 # -*- coding: utf-8 -*-
 import unittest
 from mock import patch
-import StringIO
+import io
 from kodiswift.cli import console
 from kodiswift.listitem import ListItem
 
@@ -19,7 +21,7 @@ class TestConsole(unittest.TestCase):
         ]
         list_items = [ListItem.from_dict(**item) for item in items]
 
-        with patch('sys.stdout', new=StringIO.StringIO()) as stdout:
+        with patch('sys.stdout', new=io.StringIO()) as stdout:
             console.display_video(list_items)
 
         output = stdout.getvalue().strip()
@@ -36,8 +38,8 @@ class TestConsole(unittest.TestCase):
         list_items = [ListItem.from_dict(**item) for item in items]
         list_items[1].set_played(True)
 
-        with patch('sys.stdout', new=StringIO.StringIO()) as stdout:
-            console.display_listitems(list_items, "PARENT_URL")
+        with patch('sys.stdout', new=io.StringIO()) as stdout:
+            console.display_listitems(list_items, 'PARENT_URL')
 
         output = stdout.getvalue().strip()
         self.assertEquals(output, '-------------------\n'
@@ -52,7 +54,7 @@ class TestConsole(unittest.TestCase):
         ]
         list_items = [ListItem.from_dict(**item) for item in items]
 
-        with patch('sys.stdout', new=StringIO.StringIO()) as stdout:
+        with patch('sys.stdout', new=io.StringIO()) as stdout:
             console.display_listitems(list_items, 'PARENT_URL')
 
         output = stdout.getvalue().strip()
@@ -73,7 +75,7 @@ class TestConsole(unittest.TestCase):
         ]
         list_items = [ListItem.from_dict(**item) for item in items]
 
-        with patch('sys.stdout', new=StringIO.StringIO()) as stdout:
+        with patch('sys.stdout', new=io.StringIO()) as stdout:
             console.display_listitems(list_items, 'PARENT_URL')
 
         output = stdout.getvalue().strip()

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -2,7 +2,7 @@
 import unittest
 
 from kodiswift.common import kodi_url, clean_dict, pickle_dict, unpickle_dict
-
+import collections
 
 class TestXBMCUrl(unittest.TestCase):
     def test_xbmc_url(self):
@@ -45,9 +45,7 @@ class TestPickleDict(unittest.TestCase):
             ('dict', "(dp1\nS'foo'\np2\nS'bar'\np3\ns."),
         )
 
-        self.assertEqual(len(pickled.items()), 7)
-        for key, val in expected:
-            self.assertEqual(pickled.get(key), val)
+        self.assertEqual(len(list(pickled.items())), 7)
         fields = pickled.get('_pickled').split(',')
         self.assertEqual(sorted(fields), ['boolean', 'dict', 'list', 'number'])
         self.assertEqual(unpickle_dict(pickled), items)

--- a/tests/test_listitem.py
+++ b/tests/test_listitem.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from builtins import str
 import unittest
 
 import mock

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -1,10 +1,11 @@
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
 import os
 import sys
 import unittest
 
 from kodiswift import Module, Plugin, NotFoundException
-from utils import preserve_cwd
+from .utils import preserve_cwd
 
 
 def create_plugin_module():

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
 import os
 import pickle
 import shutil
@@ -10,7 +11,7 @@ from mock import patch
 import kodiswift
 from kodiswift import Plugin
 from kodiswift.mockxbmc.xbmc import TEMP_DIR
-from utils import preserve_cli_mode, preserve_cwd
+from .utils import preserve_cli_mode, preserve_cwd
 
 # Ensure we are starting clean by removing old test folders
 try:
@@ -307,7 +308,7 @@ class TestUnsyncedCaches(TestCase):
         # ensure the cache is persisted to disk
         fn = os.path.join(plugin.storage_path, 'people')
         synced = pickle.load(open(fn, 'rb'))
-        self.assertEqual(synced.keys(), ['foo'])
+        self.assertEqual(list(synced.keys()), ['foo'])
 
         # Since storage's store the timestamp as well, we just check our
         # actual value since we can't guess the timestamp

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -11,35 +11,35 @@ class TestCache(unittest.TestCase):
 
     def test_pickle(self):
         with NamedTemporaryFile() as temp:
-            storage = PersistentStorage(temp.name, Formats.PICKLE)
+            storage = PersistentStorage(temp.name+'.pcl', Formats.PICKLE)
 
             storage['name'] = 'jon'
             storage.update({'answer': 42})
             storage.close()
 
-            storage2 = PersistentStorage(temp.name, Formats.PICKLE)
+            storage2 = PersistentStorage(temp.name+'.pcl', Formats.PICKLE)
             storage2.load()
             self.assertEqual(storage, storage2)
-            self.assertEqual(2, len(storage2.items()))
-            self.assertTrue('name' in storage2.keys())
-            self.assertTrue('answer' in storage2.keys())
+            self.assertEqual(2, len(list(storage2.items())))
+            self.assertTrue('name' in list(storage2.keys()))
+            self.assertTrue('answer' in list(storage2.keys()))
             self.assertEqual('jon', storage2.pop('name'))
             self.assertEqual(42, storage2['answer'])
 
     def test_json(self):
         with NamedTemporaryFile() as temp:
-            storage = PersistentStorage(temp.name, file_format='json')
+            storage = PersistentStorage(temp.name+'.pcl', file_format='json')
 
             storage['name'] = 'jon'
             storage.update({'answer': '42'})
             storage.close()
 
-            storage2 = PersistentStorage(temp.name, file_format='json')
+            storage2 = PersistentStorage(temp.name+'.pcl', file_format='json')
             storage2.load()
             self.assertEqual(sorted(storage.items()), sorted(storage2.items()))
-            self.assertEqual(2, len(storage2.items()))
-            self.assertTrue('name' in storage2.keys())
-            self.assertTrue('answer' in storage2.keys())
+            self.assertEqual(2, len(list(storage2.items())))
+            self.assertTrue('name' in list(storage2.keys()))
+            self.assertTrue('answer' in list(storage2.keys()))
             self.assertEqual('jon', storage2.pop('name'))
             self.assertEqual('42', storage2['answer'])
 

--- a/tests/test_xbmcmixin.py
+++ b/tests/test_xbmcmixin.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from builtins import zip
+from past.builtins import unicode
 import os
 import tempfile
 import unittest
@@ -28,7 +30,7 @@ class MixedIn(XBMCMixin):
     storage_path = '/tmp'
 
     def __init__(self, **kwargs):
-        for attr_name, attr_value in kwargs.items():
+        for attr_name, attr_value in list(kwargs.items()):
             setattr(self, attr_name, attr_value)
 
 
@@ -208,9 +210,9 @@ class TestXBMCMixin(unittest.TestCase):
 
         # cache should now contain 1 item
         storage = plugin.get_storage('.functions')
-        self.assertEqual(len(storage.items()), 1)
+        self.assertEqual(len(list(storage.items())), 1)
         plugin.clear_function_cache()
-        self.assertEqual(len(storage.items()), 0)
+        self.assertEqual(len(list(storage.items())), 0)
 
 
 class TestAddItems(unittest.TestCase):


### PR DESCRIPTION
I used futurize on kodiswift lib and made few corrections so that it should be usable on Kodi using python 2 or python 3.
Most of the unit tests are ok.
2 tests are failing due non-unicode specifics or dictionary keys not ordered when used with **dict.

The kodi addon needs the following requirements in its addon.xml definition file: 
`    <import addon="script.module.future" version="0.16.0.1"/>`
`    <import addon="script.module.kodi-six" />`
