### PR TITLE
add support of listitem subtitle and python 2 and 3 compatability with six

### DIFF
--- a/kodiswift/cli/data/addon.xml
+++ b/kodiswift/cli/data/addon.xml
@@ -3,6 +3,7 @@
   <requires>
     <import addon="xbmc.python" version="2.24.0" />
     <import addon="script.module.kodiswift" version="0.0.1" />
+    <import addon="script.module.six" />
   </requires>
   <extension point="xbmc.python.pluginsource" library="addon.py">
     <provides>video</provides>

--- a/kodiswift/common.py
+++ b/kodiswift/common.py
@@ -10,7 +10,7 @@ This module contains some common helpful functions.
 """
 from __future__ import absolute_import
 
-import urllib
+import six.moves.urllib as urllib
 
 try:
     import cPickle as pickle
@@ -39,7 +39,7 @@ def kodi_url(url, **options):
     Returns:
         str:
     """
-    options = urllib.urlencode(options)
+    options = urllib.parse.urlencode(options)
     if options:
         return url + '|' + options
     return url
@@ -141,7 +141,7 @@ def download_page(url, data=None):
     Returns:
         str: The results of requesting the URL.
     """
-    conn = urllib.urlopen(url, data)
+    conn = urllib.request.urlopen(url, data)
     resp = conn.read()
     conn.close()
     return resp

--- a/kodiswift/listitem.py
+++ b/kodiswift/listitem.py
@@ -12,6 +12,7 @@ for xbmcgui.ListItem.
 from __future__ import absolute_import
 
 import warnings
+import six
 
 from kodiswift import xbmcgui
 
@@ -266,6 +267,10 @@ class ListItem(object):
         """Adds stream details"""
         return self._listitem.addStreamInfo(stream_type, stream_values)
 
+    def set_subtitles(self, subtitlelist):
+        """Sets the listitem's subtitle"""
+        return self._listitem.setSubtitles(subtitlelist)
+
     def as_tuple(self):
         """Returns a tuple of list item properties:
             (path, the wrapped xbmcgui.ListItem, is_folder)
@@ -281,7 +286,7 @@ class ListItem(object):
                   path=None, selected=None, info=None, properties=None,
                   context_menu=None, replace_context_menu=False,
                   is_playable=None, info_type='video', stream_info=None,
-                  **kwargs):
+				  setsubtitles=None, **kwargs):
         """A ListItem constructor for setting a lot of properties not
         available in the regular __init__ method. Useful to collect all
         the properties in a dict and then use the **dct to call this
@@ -321,6 +326,9 @@ class ListItem(object):
         if context_menu:
             listitem.add_context_menu_items(context_menu, replace_context_menu)
 
+        if setsubtitles!=[] and setsubtitles!='' and setsubtitles is not None:
+            listitem.set_subtitles(setsubtitles)
+
         return listitem
 
     def __eq__(self, other):
@@ -333,7 +341,7 @@ class ListItem(object):
         return self_props == other_props
 
     def __str__(self):
-        return ('%s (%s)' % (self.label, self.path)).encode('utf-8')
+        return six.ensure_str(('%s (%s)' % (self.label, self.path)), encoding='utf-8')
 
     def __repr__(self):
-        return ("<ListItem '%s'>" % self.label).encode('utf-8')
+        return six.ensure_str(("<ListItem '%s'>" % self.label), encoding='utf-8')

--- a/kodiswift/mockxbmc/polib.py
+++ b/kodiswift/mockxbmc/polib.py
@@ -428,7 +428,6 @@ class _BaseFile(list):
             fhandle = open(fpath, 'wb')
         else:
             fhandle = io.open(fpath, 'w', encoding=self.encoding)
-            #if not isinstance(contents, six.text_type):
             contents = six.ensure_text(contents, encoding=self.encoding)
         fhandle.write(contents)
         fhandle.close()
@@ -618,9 +617,7 @@ class POFile(_BaseFile):
             else:
                 ret += '# %s\n' % header
 
-        #if not isinstance(ret, text_type):
-        #    ret = ret.decode(self.encoding)
-		ret = six.u(ret)
+		ret = six.ensure_text(ret)
 
         return ret + _BaseFile.__unicode__(self)
 

--- a/kodiswift/mockxbmc/polib.py
+++ b/kodiswift/mockxbmc/polib.py
@@ -24,6 +24,7 @@ import re
 import struct
 import sys
 import textwrap
+import six
 
 try:
     import io
@@ -220,8 +221,7 @@ def detect_encoding(file, binary_mode=False):
             if match:
                 f.close()
                 enc = match.group(1).strip()
-                if not isinstance(enc, text_type):
-                    enc = enc.decode('utf-8')
+				enc = six.ensure_text(enc)
                 if charset_exists(enc):
                     return enc
         f.close()
@@ -428,8 +428,8 @@ class _BaseFile(list):
             fhandle = open(fpath, 'wb')
         else:
             fhandle = io.open(fpath, 'w', encoding=self.encoding)
-            if not isinstance(contents, text_type):
-                contents = contents.decode(self.encoding)
+            #if not isinstance(contents, six.text_type):
+            contents = six.ensure_text(contents, encoding=self.encoding)
         fhandle.write(contents)
         fhandle.close()
         # set the file path if not set
@@ -618,8 +618,9 @@ class POFile(_BaseFile):
             else:
                 ret += '# %s\n' % header
 
-        if not isinstance(ret, text_type):
-            ret = ret.decode(self.encoding)
+        #if not isinstance(ret, text_type):
+        #    ret = ret.decode(self.encoding)
+		ret = six.u(ret)
 
         return ret + _BaseFile.__unicode__(self)
 
@@ -1683,8 +1684,8 @@ class _MOFileParser(object):
                     tokens = line.split(b(':'), 1)
                     if tokens[0] != b(''):
                         try:
-                            k = tokens[0].decode(encoding)
-                            v = tokens[1].decode(encoding)
+                            k = six.ensure_text(tokens[0], encoding=encoding)
+                            v = six.ensure_text(tokens[1], encoding=encoding)
                             metadata[k] = v.strip()
                         except IndexError:
                             metadata[k] = u('')

--- a/kodiswift/urls.py
+++ b/kodiswift/urls.py
@@ -12,7 +12,6 @@ from __future__ import absolute_import
 
 import re
 import six.moves.urllib as urllib
-#from urllib import urlencode, unquote_plus, quote_plus
 
 from kodiswift.common import pickle_dict, unpickle_dict
 

--- a/kodiswift/urls.py
+++ b/kodiswift/urls.py
@@ -11,7 +11,8 @@ This module contains URLRule class for dealing with url patterns.
 from __future__ import absolute_import
 
 import re
-from urllib import urlencode, unquote_plus, quote_plus
+import six.moves.urllib as urllib
+#from urllib import urlencode, unquote_plus, quote_plus
 
 from kodiswift.common import pickle_dict, unpickle_dict
 
@@ -104,7 +105,7 @@ class UrlRule(object):
             raise NotFoundException
 
         # urlunencode the values
-        items = dict((key, unquote_plus(val))
+        items = dict((key, urllib.parse.unquote_plus(val))
                      for key, val in m.groupdict().items())
 
         # unpickle any items if present
@@ -125,7 +126,7 @@ class UrlRule(object):
             if not isinstance(val, basestring):
                 raise TypeError('Value "%s" for key "%s" must be an instance'
                                 ' of basestring' % (val, key))
-            items[key] = quote_plus(val)
+            items[key] = urllib.parse.quote_plus(val)
 
         try:
             path = self._url_format.format(**items)
@@ -141,7 +142,7 @@ class UrlRule(object):
         and values in the provided items will be urlencoded. If necessary, any
         python objects will be pickled before being urlencoded.
         """
-        return urlencode(pickle_dict(items))
+        return urllib.parse.urlencode(pickle_dict(items))
 
     def make_path_qs(self, items):
         """Returns a relative path complete with query string for the given

--- a/kodiswift/xbmcmixin.py
+++ b/kodiswift/xbmcmixin.py
@@ -11,6 +11,7 @@ from kodiswift import xbmc, xbmcplugin, xbmcgui
 from kodiswift.constants import SortMethod
 from kodiswift.logger import log
 from kodiswift.storage import TimedStorage, UnknownFormat
+import six
 
 __all__ = ['XBMCMixin']
 
@@ -216,7 +217,7 @@ class XBMCMixin(object):
         if converter is str:
             return value
         elif converter is unicode:
-            return value.decode('utf-8')
+            return six.ensure_text(value, encoding='utf-8')
         elif converter is bool:
             return value == 'true'
         elif converter is int:


### PR DESCRIPTION
I add support of `setsubtitle` function and make listitem able to display the subtitle in a listitem object.
Also I incorporate the `six` library to enhance the compatibility in python 2 and 3. 

In cli mode(run interactive) test would fail, saying that no function of setsubtitle, but in Kodi runtime it would run without any error.